### PR TITLE
Feature/terraform-modulos-iniciales

### DIFF
--- a/src/builder/main.tf
+++ b/src/builder/main.tf
@@ -1,0 +1,8 @@
+resource "null_resource" "env_builder" {
+  triggers = {
+    env_name = var.env_name
+    env_type   = var.env_type
+    env_count       = var.env_count
+    total          = "Crear ${env_count} ${env_name}-${env_type}"
+  }
+}

--- a/src/builder/outputs.tf
+++ b/src/builder/outputs.tf
@@ -1,0 +1,4 @@
+output "create_builder" {
+  value       = "Creados ${cantidad} ${nombre_entorno} de tipo ${tipo_entorno}"
+  description = "Genera un entorno paso a paso."
+}

--- a/src/builder/variables.tf
+++ b/src/builder/variables.tf
@@ -1,0 +1,17 @@
+variable "env_name" {
+  type        = string
+  default     = "Ubuntu VM"
+  description = "Nombre del entorno."
+}
+
+variable "env_type" {
+  type        = string
+  default     = "Ubuntu"
+  description = "Tipo del entorno."
+}
+
+variable "env_count" {
+  type        = number
+  default     = 5
+  description = "Cantidad de entornos a crear."
+}

--- a/src/composite/main.tf
+++ b/src/composite/main.tf
@@ -1,0 +1,14 @@
+resource "null_resource" "parent_resource" {
+  triggers = {
+    parent_name = var.parent_name
+  }
+}
+
+resource "null_resource" "childs_resources" {
+  count = var.child_count
+
+  triggers = {
+    id    = count.index
+    parent = var.parent_name
+  }
+}

--- a/src/composite/outputs.tf
+++ b/src/composite/outputs.tf
@@ -1,0 +1,4 @@
+output "generate_structure" {
+  value       = "Padre: ${var.nombre_padre} con ${var.cant_hijos} hijos."
+  description = "Cantidad de hijos generada en base del recurso padre."
+}

--- a/src/composite/variables.tf
+++ b/src/composite/variables.tf
@@ -1,0 +1,11 @@
+variable "parent_name" {
+  type        = string
+  description = "Nombre del recurso padre"
+  default     = "Padre"
+}
+
+variable "child_count" {
+  type        = number
+  description = "Cantidad de recursos hijo a crear."
+  default     = 5
+}

--- a/src/factory/main.tf
+++ b/src/factory/main.tf
@@ -1,0 +1,6 @@
+resource "null_resource" "product" {
+  triggers = {
+    type     = var.resource_type
+    count = var.product_count
+  }
+}

--- a/src/factory/outputs.tf
+++ b/src/factory/outputs.tf
@@ -1,0 +1,4 @@
+output "create_resource" {
+  value       = var.resource_type
+  description = "Tipo de recurso generado por la fábrica."
+}

--- a/src/factory/variables.tf
+++ b/src/factory/variables.tf
@@ -1,0 +1,11 @@
+variable "resource_type" {
+  type        = string
+  description = "Tipo de recurso a crear ('local', 'web', 'VM')."
+  default     = "local"
+}
+
+variable "product_count" {
+  type        = number
+  description = "Cantidad de recursos a crear."
+  default     = 1
+}

--- a/src/prototype/main.tf
+++ b/src/prototype/main.tf
@@ -1,0 +1,8 @@
+resource "null_resource" "clone_generator" {
+  clone_count = var.count
+
+  triggers = {
+    config   = var.clon_config
+    clone_id = count.index
+  }
+}

--- a/src/prototype/outputs.tf
+++ b/src/prototype/outputs.tf
@@ -1,0 +1,5 @@
+output "Create_clones" {
+  value       = var.count
+  description = "Cantidad de clones generados desde el prototipo."
+  
+}

--- a/src/prototype/variables.tf
+++ b/src/prototype/variables.tf
@@ -1,0 +1,11 @@
+variable "clon_config" {
+  type        = string
+  description = "Prototipo general de cada clon"
+  default     = "clon-v1"
+}
+
+variable "count" {
+  type        = number
+  description = "Número de clones a crear."
+  default     = 2
+}

--- a/src/singleton/main.tf
+++ b/src/singleton/main.tf
@@ -1,0 +1,8 @@
+resource "null_resource" "Instance_object" {
+
+  validator = var.count ? 0 : 1
+
+  triggers = {
+    instance_name = var.instance_name
+  }
+}

--- a/src/singleton/outputs.tf
+++ b/src/singleton/outputs.tf
@@ -1,0 +1,4 @@
+output "create_instance" {
+  value       = val.cantidad ? "Instancia ${var.nombre} creada con exito." : "Instancia ya creada."
+  description = "Estado de creación de la istancia global."
+}

--- a/src/singleton/variables.tf
+++ b/src/singleton/variables.tf
@@ -1,0 +1,11 @@
+variable "instance_name" {
+  type        = string
+  description = "Nombre de la instancia."
+  default     = ""
+}
+
+variable "count" {
+  type        = bool
+  description = "Permite crear la instancia."
+  default     = false # no existe la instancia, por lo que se crea
+}


### PR DESCRIPTION
Creación de los modulos iniciales en terraform para los patrones de diseño aplicados a IaC.
Al ser una estructura inicial solo hay conceptos básicos para cada patrón, variables acorde al patrón y una salida única.

closes #3 