### PR TITLE
feat(src): agregar generar_diagrama.py y archivos de configuracion

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,9 @@
+skips: 
+  - B101  #prueba de uso de asercion
+  - B307  #inseguro uso de hash 
+
+targets:
+  - src/diagrams/generar_diagrama.py
+
+output-format: txt
+quiet: False

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 88
+exclude =
+    .git,
+    __pycache__,
+    venv
+
+# E203 espacio antes de ':' 
+# W503 advertir sobre linea rota luego de operador binario
+extend-ignore =
+    E203,  
+    W503   

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+#entorno virtuales 
+venv/
+.env/
+
+#archivos temporales  
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+#info 
+*.egg-info/
+
+# diagramas 
+*.dot
+*.gv
+*.png
+*.svg
+
+# log 
+*.log

--- a/src/diagrams/generar_diagrama.py
+++ b/src/diagrams/generar_diagrama.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import argparse
+
+def generar_diagrama(pattern: str, salida: str):
+    print("Patrones: ", pattern, ": ", salida)
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Diagrama:"
+    )
+    parser.add_argument(
+        "-p", "--pattern",
+        required=True,
+        choices=["singleton", "composite", "factory", "prototype", "builder"]
+    )
+    parser.add_argument(
+        "-o", "--output",
+        default="diagram.png"
+    )
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    args = parse_args()
+    generar_diagrama(args.pattern, args.output)


### PR DESCRIPTION
Se agrego el script generar_diagrama.py con una estructura base como punto de partida para la generación de diagramas, ya que aun no se ha implementado la función principal. También se incluyeron los archivos de configuración del entorno .gitignore, .flake8 y .bandit, que ayudaran a tener buenas practicas en el proyecto. 

closes #5 