### PR TITLE
test(generar_diagrama): agregar pruebas unitarias para generar_diagrama

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+minversion = 6.0
+pythonpath = .
+addopts = -ra -q
+testpaths = tests
+python_files = test_*.py

--- a/tests/test_generar_diagrama.py
+++ b/tests/test_generar_diagrama.py
@@ -1,0 +1,34 @@
+import io
+import sys
+import pytest
+from scripts.generar_diagrama import parse_args, generar_diagrama
+
+def test_parse_args_minimal(tmp_path, monkeypatch):
+    """
+    Verifica que el argumento --pattern se procese correctamente 
+    y que --output tome el valor por defecto cuando no se especifica.
+    """
+    # No mostará warnings innecesarios durante la prueba
+    monkeypatch.setenv("PYTHONWARNINGS", "ignore")
+
+    # Simular argumentos pasados por consola
+    sys_argv = ["generar_diagrama.py", "-p", "singleton"]
+    monkeypatch.setattr(sys, "argv", sys_argv)
+
+    # Ejecutar el parser de argumentos
+    args = parse_args()
+
+    assert args.pattern == "singleton"
+    assert args.output == "diagram.png"
+
+def test_generar_diagrama_prints_correctly(capsys):
+    """
+    Comprobar que la función generar_diagrama imprima correctamente
+    el mensaje con el nombre del patrón y el archivo de salida.
+    """
+
+    generar_diagrama("factory", "out.png")
+
+    captured = capsys.readouterr()
+
+    assert "Patrones:  factory :  out.png" in captured.out

--- a/tests/test_generar_diagrama1.py
+++ b/tests/test_generar_diagrama1.py
@@ -1,0 +1,41 @@
+import sys
+import pytest
+from pathlib import Path
+
+@pytest.fixture(autouse=True)
+def add_project_root_to_syspath(monkeypatch):
+    """
+    Asegura que 'scripts/' sea importable como paquete.
+    """
+    project_root = Path(__file__).parent.parent.resolve()
+    monkeypatch.syspath_prepend(str(project_root))
+
+def test_parse_args_minimal(monkeypatch):
+    # --pattern es obligatorio, --output por defecto
+    monkeypatch.setenv("PYTHONWARNINGS", "ignore")
+    monkeypatch.setattr(sys, "argv", ["generar_diagrama.py", "-p", "singleton"])
+    from scripts.generar_diagrama import parse_args
+
+    args = parse_args()
+    assert args.pattern == "singleton"
+    assert args.output == "diagram.png"
+
+def test_parse_args_with_output(monkeypatch):
+    # Combinación -p y -o
+    monkeypatch.setattr(sys, "argv", ["generar_diagrama.py", "-p", "factory", "-o", "foo.png"])
+    from scripts.generar_diagrama import parse_args
+
+    args = parse_args()
+    assert args.pattern == "factory"
+    assert args.output == "foo.png"
+
+def test_generar_diagrama_prints_correctly(capsys):
+    # Verifica que la función imprime el texto esperado
+    from scripts.generar_diagrama import generar_diagrama
+
+    generar_diagrama("composite", "out.png")
+    captured = capsys.readouterr().out
+
+    assert "Patrones:" in captured
+    assert "composite" in captured
+    assert "out.png" in captured


### PR DESCRIPTION
Se agrego pruebas unitarias para la función generar_diagrama. Las pruebas se implementó con pytest y estas se mantienen independientes entre sí. Esto permite asegurar el correcto funcionamiento de la función bajo distintos escenarios.

Closes #7 