### PR TITLE
Feature/modulo-prototype

### DIFF
--- a/src/prototype/example.tf
+++ b/src/prototype/example.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "mi_clon"{
+    triggers = {
+        env   = "entorno_basico"
+    }
+}

--- a/src/prototype/main.tf
+++ b/src/prototype/main.tf
@@ -1,5 +1,12 @@
-resource "null_resource" "clone_generator" {
-  triggers = {
-    config   = var.clon_config
+resource "local_file" "prototype_generator" {
+  content  = data.template_file.prototype.rendered
+  filename = "${path.module}/example.tf"
+}
+
+data "template_file" "prototype_template" {
+  template = file("${path.module}/templates/prototype.hcl.tpl")
+  vars = {
+    name = var.name
+    env  = var.env
   }
 }

--- a/src/prototype/outputs.tf
+++ b/src/prototype/outputs.tf
@@ -1,5 +1,3 @@
-output "Create_clones" {
-  value       = var.counter
-  description = "Cantidad de clones generados desde el prototipo."
-  
+output "create_clon" {
+  value = "Prototipo generado con exito."
 }

--- a/src/prototype/scripts/clone_prototype.py
+++ b/src/prototype/scripts/clone_prototype.py
@@ -1,0 +1,81 @@
+import sys
+import os
+import time
+import copy
+
+class TerraformPrototype:
+    """
+    Clase que representa un prototipo de archivo Terraform.
+    Permite clonar el archivo y reemplazar variables en su contenido.
+    """
+    def __init__(self, filepath, replacements):
+        """
+        Inicializa el prototipo con la ruta del archivo y las variables a reemplazar.
+        """
+        self.filepath = filepath
+        self.replacements = replacements
+        self.content = self._read_file()
+
+    def _read_file(self):
+        """
+        Lee el contenido del archivo original y lo retorna como string.
+        """
+        with open(self.filepath, "r") as file:
+            return file.read()
+
+    def clone(self):
+        """
+        Clona el prototipo usando copy.deepcopy y reemplaza las variables en el contenido.
+        """
+        # Se hace una copia del objeto actual
+        prototype_copy = copy.deepcopy(self)
+        # Por cada variable a reemplazar, se hace el cambio en el contenido
+        # diccionario
+        for key, value in prototype_copy.replacements.items():
+            prototype_copy.content = prototype_copy.content.replace(key, value)
+        return prototype_copy
+
+    def save(self, output_path):
+        """
+        Guarda el contenido modificado en un nuevo archivo.
+        """
+        with open(output_path, "w") as file:
+            file.write(self.content)
+
+def create_clone():
+    """
+    Función principal que gestiona la clonación del archivo Terraform.
+    """
+    # Directorio actual del script
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    # Subir un nivel para obtener la raíz del proyecto ("prototype/")
+    base_dir = os.path.abspath(os.path.join(script_dir, ".."))
+
+    # Ruta al archivo plantilla
+    template_tf = os.path.join(base_dir, "templates", "prototype.hcl.tpl")
+
+    # Verifica que la plantilla exista
+    if not os.path.isfile(template_tf):
+        print(f"Archivo no encontrado.")
+        sys.exit(1)
+
+    # Genera un timestamp para el archivo clonado
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    clon_file = f"example_{timestamp}.tf"
+    out_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), clon_file)
+
+    # Diccionario con las variables a reemplazar
+    replacements = {
+        "entorno_basico": f"clon_{timestamp}"
+    }
+
+    # Crea el prototipo, lo clona y guarda el resultado
+    prototype = TerraformPrototype(template_tf, replacements)
+    clon = prototype.clone()
+    clon.save(out_path)
+
+    print(f"Archivo clonado y modificado.")
+
+if __name__ == "__main__":
+    create_clone()

--- a/src/prototype/templates/prototype.hcl.tpl
+++ b/src/prototype/templates/prototype.hcl.tpl
@@ -1,0 +1,5 @@
+resource "null_resource" "${name}"{
+    triggers = {
+        env   = "${env}"
+    }
+}

--- a/src/prototype/variables.tf
+++ b/src/prototype/variables.tf
@@ -1,11 +1,9 @@
-variable "clon_config" {
-  type        = string
-  description = "Prototipo general de cada clon"
-  default     = "clon-v1"
+variable "name" {
+  type    = string
+  default = "mi_clon"
 }
 
-variable "counter" {
-  type        = number
-  description = "Número de clones a crear."
-  default     = 2
+variable "env" {
+  type    = string
+  default = "entorno_basico"
 }


### PR DESCRIPTION
# feat
- Agregué lógica para la creación de recursos prototipos en terraform a base de un template, este template puede ser modificado dependiendo del recurso o recursos que se quiere crear.
- Creación de script `clone_prototype.py` que lee el prototipo y hace una copia profunda (deepcopy) de los recursos, modifica algunas variables y genera clones.
- Los clones se identificarán por un timestamp.

# fix
- Cambio en `variables.tf`, `output.tf` para que las variables estén acorde al modulo donde han sido creados.

Closes #23 