### PR TITLE
Feature/modulo-factory

### DIFF
--- a/src/factory/main.tf
+++ b/src/factory/main.tf
@@ -1,6 +1,30 @@
-resource "null_resource" "product" {
-  triggers = {
-    type     = var.resource_type
-    count = var.product_count
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.2.3" 
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.4.3" 
+    }
   }
+}
+
+# Producto A: crea un archivo local
+# Solo se aplica si el tipo de fábrica es "local_file"
+resource "local_file" "product_file" {
+  count    = var.factory_type == "local_file" ? 1 : 0
+
+  content  = var.file_content
+  # El archivo se guarda en factory_module/
+  filename = var.file_name 
+}
+
+# Producto B: genera un ID aleatorio
+# Solo se aplica si el tipo de fábrica es "random_id"
+resource "random_id" "product_id" {
+  count = var.factory_type == "random_id" ? 1 : 0
+
+  byte_length = var.random_byte_length
 }

--- a/src/factory/outputs.tf
+++ b/src/factory/outputs.tf
@@ -1,4 +1,25 @@
-output "create_resource" {
-  value       = var.resource_type
-  description = "Tipo de recurso generado por la fábrica."
+output "product_details" {
+  description = "Detalles del recurso creado por la fábrica."
+  value = {
+    type_created = var.factory_type
+    #  si el recurso no fue creado usamos try 
+    id = try(
+      one(
+        concat(
+          local_file.product_file.*.id,
+          random_id.product_id.*.id
+        )
+      ), 
+      "N/A (recurso no creado para este tipo)"
+    )
+    details = try(
+      one(
+        concat(
+          [for f in local_file.product_file : "Archivo creado en: ${f.filename}"],
+          [for r in random_id.product_id : "ID aleatorio (hex): ${r.hex}"]
+        )
+      ),
+      "N/A (recurso no creado para este tipo)"
+    )
+  }
 }

--- a/src/factory/producto_local_file.txt
+++ b/src/factory/producto_local_file.txt
@@ -1,0 +1,1 @@
+Archivo generado por la fábrica.

--- a/src/factory/run_factory.sh
+++ b/src/factory/run_factory.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR" || exit
+
+# Configuración inicial
+FACTORY_TYPE=${1:-local_file}
+CONFIG_FILE="factory_config.json"
+
+# Validar tipo de fábrica
+if [[ "$FACTORY_TYPE" != "local_file" && "$FACTORY_TYPE" != "random_id" ]]; then
+  echo "Error: tipo de fábrica no válido. Usa 'local_file' o 'random_id'."
+  exit 1
+fi
+
+echo "Iniciando fábrica: tipo '$FACTORY_TYPE'"
+
+# Generar archivo de configuración
+echo "Generando archivo '$CONFIG_FILE'..."
+cat <<EOF > $CONFIG_FILE
+{
+  "factory_type": "${FACTORY_TYPE}",
+  "file_name": "producto_${FACTORY_TYPE}.txt",
+  "file_content": "Archivo generado por la fábrica.",
+  "random_byte_length": 8
+}
+EOF
+
+echo "Ejecutando Terraform..."
+terraform init -upgrade > /dev/null
+terraform apply -auto-approve -var-file="./${CONFIG_FILE}"
+
+# Limpieza
+echo "Eliminando archivo de configuración..."
+rm $CONFIG_FILE
+
+echo "Proceso completado."

--- a/src/factory/variables.tf
+++ b/src/factory/variables.tf
@@ -1,11 +1,26 @@
-variable "resource_type" {
+variable "factory_type" {
   type        = string
-  description = "Tipo de recurso a crear ('local', 'web', 'VM')."
-  default     = "local"
+  description = "El tipo de producto a crear. Valores válidos: 'local_file' o 'random_id'."
+  validation {
+    condition     = contains(["local_file", "random_id"], var.factory_type)
+    error_message = "El valor de factory_type debe ser 'local_file' o 'random_id'."
+  }
 }
 
-variable "product_count" {
+variable "file_name" {
+  type        = string
+  description = "Nombre del archivo a crear si factory_type es 'local_file'."
+  default     = "default.txt"
+}
+
+variable "file_content" {
+  type        = string
+  description = "Contenido del archivo a crear."
+  default     = "Archivo por defecto."
+}
+
+variable "random_byte_length" {
   type        = number
-  description = "Cantidad de recursos a crear."
-  default     = 1
+  description = "Longitud en bytes para el ID aleatorio si factory_type es 'random_id'."
+  default     = 8
 }


### PR DESCRIPTION
Se implementó el módulo Terraform “factory” que crea recursos de forma condicional (local_file o random_id según el valor de var.factory_type) y un script Bash (run_factory.sh) que genera automáticamente el archivo factory_config.json

Closes #22 