### PR TITLE
feature/hook-pre-hook

### DIFF
--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+# nombre de la rama 
+branch_name=$(git rev-parse --abbrev-ref HEAD)
+
+# Bloquear push desde main 
+if [[ "$branch_name" == "main" ]]; then
+    echo "❌ Push directo a '$branch_name' bloqueado. Usa una rama feature/*"
+    exit 1
+fi
+
+echo "✅ Push permitido desde la rama '$branch_name'"
+exit 0


### PR DESCRIPTION
Se implemento un hook de push para prevenir que se hagan push directamente a la rama main. Esto nos permitirá realizar buenas prácticas al forzar el trabajo en ramas feature/* debido a que nos impedira realizar un push desde la rama main por error 

Closes #19 